### PR TITLE
require guzzle/guzzle (version 3) instead of guzzlehttp/guzzle to avo…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     },
     "require": {
         "php": ">=5.3.3",
-        "guzzlehttp/guzzle": "~3.0"
+        "guzzle/guzzle": "~3.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.4"


### PR DESCRIPTION
…id version conflicts in projects also requiring newer versionss of guzzle (using the guzzlehttp namespace)