### PR TITLE
require guzzle/guzzle (version 3) instead of guzzlehttp/guzzle to…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,4 @@ before_script:
   - composer install
 
 script:
-  - phpunit
+  - ./vendor/phpunit/phpunit/phpunit

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     },
     "require": {
         "php": ">=5.3.3",
-        "guzzlehttp/guzzle": "~3.0"
+        "guzzle/guzzle": "~3.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.4"


### PR DESCRIPTION
…avoid version conflicts in projects also requiring newer versions of guzzle (only available under the new guzzlehttp namespace)

use locally installed verion of phpunit for travis-ci